### PR TITLE
Switch to jsondown.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,7 @@ var utils = require('./utils');
 var config = {
   PORT: 8080,
   plugins: ['brain', 'census', 'settings', 'command', 'content', 'timer', 'namer', 'glob', 'tags'],
-  STATE_DIR_PATH: 'state',
+  STATE_PATH: './state.json',
 };
 
 

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "url": "https://github.com/mythmon/corsica/issues"
   },
   "dependencies": {
-    "lvl": "0.1.3",
-    "socket.io": "0.9.16",
     "es6-promise": "0.1.2",
     "express": "3.4.8",
+    "jsondown": "^0.1.1",
+    "levelup": "^0.19.0",
+    "minimatch": "0.2.14",
+    "proxied-promise-object": "^0.2.0",
     "request": "2.34.0",
-    "minimatch": "0.2.14"
+    "socket.io": "0.9.16"
   }
 }


### PR DESCRIPTION
This stores the Brain state in a JSON file in a semi-human readable format. In particular, it is a JSON object who's values are JSON string encodings of JS objects.

This also keeps everything in memory always, and sync's it back to disk. It's probably fine for us.

This is a change in format from the leveldb backend, and will require manual intervention (or to throw away all the old state). Things stored in state include timer configs, group playlists, and irc configs.
