### PR TITLE
change toast default to indefinite

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -77,7 +77,9 @@ var toastEl = document.querySelector('#toast');
 function toast(message, timeout) {
   toastEl.textContent = message;
   toastEl.classList.add('show');
-  toastTimeout = setTimeout(untoast, timeout || 5000);
+  if (timeout > -1) {
+    toastTimeout = setTimeout(untoast, timeout);
+  }
 }
 
 function untoast() {


### PR DESCRIPTION
fixes issue #29 by changing `toast` to only set a timeout if the timeout is provided and is 0 or greater. `ident` provides an explicit timeout, so that remains unchanged. 
