### PR TITLE
enable auto push to npm on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+- '0.11'
+- '0.10'
 matrix:
   allow_failures:
-    - node_js: "0.11"
+  - node_js: '0.11'
 branches:
   only:
-    - master
+  - master
 install:
-    - npm install
-    - npm install jshint
+- npm install
+- npm install jshint
 script:
-    - jshint .
-    - npm test
+- jshint .
+- npm test
 notifications:
   email: false
+deploy:
+  provider: npm
+  email: lonnen@mozilla.com
+  api_key:
+    secure: a+RxKYrMVIA7B/SiphMVLBVlaeuufTwas6bdUlYCJWlzMugtKBDqnYu4NN9qTdQIOmy5Z0zgnOxvf8VQEfLQ3B3rJTw6/JSl3FlSfmoiWmTxRJx4MCYXpJykAgvdZeKIysG91watX/BQRYS3LR8KkxER/coqiLoOMtZwAfrQO2Y=
+  on:
+    tags: true
+    repo: mozilla/corsica


### PR DESCRIPTION
tags on the mozilla/corsica repo will auto push to npm when travis tests pass

`travis-ci` tools also tweaked the formatting while I was in there. The deploy section is the only new bit

fixed issue #31 
