### PR TITLE
Add per-screen variable timing.

### DIFF
--- a/plugins/timer.js
+++ b/plugins/timer.js
@@ -58,8 +58,14 @@ module.exports = function (corsica) {
      */
     return settings.get()
       .then(function(settings) {
-        var resetTime = +settings.resetTime;
-        var jitter = +settings.jitter;
+        var resetTime, jitter;
+        if ('screens' in settings && name in settings.screens) {
+          resetTime = parseInt(settings.screens[name].resetTime || settings.resetTime);
+          jitter = parseInt(settings.screens[name].jitter || settings.jitter);
+        } else {
+          resetTime = +settings.resetTime;
+          jitter = +settings.jitter;
+        }
         var offset = jitter * (Math.random() * 2 - 1);
         var timeout = resetTime + offset;
         return utils.timerPromise(timeout);


### PR DESCRIPTION
I decided that for the goals I have (getting corsica in the engineering area in mozpdx), having per-screen variable timers would be better than per-tag or per-content. Additionally, doing it this way instead of moving timers to the client is a) easy, and b) I don't want to move things to the client, I want to move them to the corisca-state repo.

r?
