### PR TITLE
add time ranges to tags plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: no
 language: node_js
 node_js:
-- '0.11'
-- '0.10'
+- '4.7.3'
+- '7.5.0'
 matrix:
   allow_failures:
   - node_js: '0.11'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: node_js
 node_js:
 - '4.7.3'
 - '7.5.0'
-matrix:
-  allow_failures:
-  - node_js: '0.11'
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "es6-promise": "0.1.2",
     "express": "3.4.8",
-    "minimatch": "0.2.14",
-    "request": "2.34.0",
-    "socket.io": "0.9.16"
+    "minimatch": "^3.0.3",
+    "request": "^2.80.0",
+    "socket.io": "^1.7.3"
   }
 }

--- a/plugins/command.js
+++ b/plugins/command.js
@@ -96,7 +96,7 @@ function parser(str, msg) {
     msgType = 'content';
   }
 
-  return {type: msgType, message: msg}
+  return {type: msgType, message: msg};
 }
 
 module.exports.parser = parser;

--- a/plugins/tags.js
+++ b/plugins/tags.js
@@ -80,6 +80,29 @@ module.exports = function (corsica) {
           }
         });
 
+        commands = commands.filter(function (command) {
+          var c = corsica.parseCommand(command).message;
+
+          var from;
+          var to;
+
+          if (c.from) {
+            from = Date.parse(c.from);
+          } else {
+            from = 0;
+          }
+
+          if (c.to) {
+            to = Date.parse(c.to);
+          } else {
+            to = Infinity;
+          }
+
+          var now = Date.now();
+
+          return from < now && now < to;
+        });
+
         console.log('sampling from', commands.length, 'commands:', commands);
 
         if (commands.length) {

--- a/tests/plugins/command_test.js
+++ b/tests/plugins/command_test.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var commandPlugin = require('../../plugins/command');
 
 function result(o) {
-  return Object.assign({ message: { _args: [] } }, o)
+  return Object.assign({ message: { _args: [] } }, o);
 }
 
 assert.deepEqual(

--- a/tests/plugins/command_test.js
+++ b/tests/plugins/command_test.js
@@ -2,10 +2,58 @@ var assert = require('assert');
 
 var commandPlugin = require('../../plugins/command');
 
+function result(o) {
+  return Object.assign({ message: { _args: [] } }, o)
+}
 
-assert.deepEqual(commandPlugin.parser('foo'), ['foo']);
-assert.deepEqual(commandPlugin.parser('foo bar'), ['foo', 'bar']);
-assert.deepEqual(commandPlugin.parser('"foo bar"'), ['foo bar']);
-assert.deepEqual(commandPlugin.parser('"foo bar" "baz=qux wat"'), ['foo bar', 'baz=qux wat']);
-assert.deepEqual(commandPlugin.parser('foo\\"bar'), ['foo"bar']);
-assert.deepEqual(commandPlugin.parser('x "y \\"z\\" w"'), ['x', 'y "z" w']);
+assert.deepEqual(
+  commandPlugin.parser('foo'),
+  result({
+    type: 'foo'
+  })
+);
+
+assert.deepEqual(
+  commandPlugin.parser('foo bar'),
+  result({
+    type: 'foo',
+    message: {
+      _args: ['bar']
+    }
+  })
+);
+
+assert.deepEqual(
+  commandPlugin.parser('"foo bar"'),
+  result({
+    type: 'foo bar'
+  })
+);
+
+assert.deepEqual(
+  commandPlugin.parser('foo bar baz=qux wat'),
+  result({
+    type: 'foo',
+    message: {
+      _args: ['bar', 'wat'],
+      baz: 'qux'
+    }
+  })
+);
+
+assert.deepEqual(
+  commandPlugin.parser('foo\\"bar'),
+  result({
+    type: 'foo"bar'
+  })
+);
+
+assert.deepEqual(
+  commandPlugin.parser('x "y \\"z\\" w"'),
+  result({
+    type: 'x',
+    message: {
+      _args: ['y "z" w']
+    }
+  })
+);


### PR DESCRIPTION
Tags now understand an option `from` and `to` field, which can be any string that can be validly parsed by `Date.parse()`. Content outside the range will be excluded from reset.