### PR TITLE
warn about fullscreen in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Corsica is a server for coordinating screens via web browsers. Content comes fro
 
 Chat bots, browser plugins, or website widgets can use the API to control nearby screens. This is useful for Posting graphs, GIFs, slides, or public announcements. Plugins provide a playlist-like rotation from a list of URLs for ambient dashboards of application metrics, promotional pages, event calendars, etc.
 
-Since Corsica can push content to any modern webbrowser the screens can be monitors, tablets, phones, smart TVs, cars, etc.
+Since Corsica can push content to any modern web browser the screens can be monitors, tablets, phones, smart TVs, cars, etc.
 
 ## How do I extend Corsica?
 
@@ -52,4 +52,16 @@ content type=html content="<style>@keyframes AnimationName{0%{background-positio
 Requests can be made to external APIs and the result can be used in the creation of a new URL or new static content.
 ```
 meme decreux dost thou even hoist? -> http://www.somememe.com/2rwhmpt.jpg -> content type=url url=http://www.somememe.com/2rwhmpt.jpg
+```
+
+## How do I set up a Kiosk client?
+
+Corsica clients rely on WebAPIs that MUST be initiated by a user action in modern web browsers. You may find it useful to change your browser configuration on managed deployments (Raspberry Pi, Mac Mini, NUC).
+
+Launch Chrome with the kiosk flag: `--kiosk "<<your corsica server url>>"`
+
+If you're running in Firefox, you can change the following preferences in `about:preferences` or add the following lines to `user.js` in the profile directory:
+```
+user_pref("full-screen-api.allow-trusted-requests-only", false);
+user_pref("full-screen-api.approval-required", false);
 ```

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -374,7 +374,10 @@ function toggleFullScreen(elem) {
 function setupFullscreen() {
     var contentElem = document.querySelector('#app');
 
-    // Be optimistic, this might work.
+    // optimistic attempt for dedicated ambient displays that
+    // are modified to allow fullscreen without user action
+    // i.e. kiosk setups without dedicated inputs
+    console.log("trying kiosk mode, may throw an uncatchable TypeError");
     requestFullscreen(contentElem);
 
     document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
Corsica client makes an optimistic attempt to initiate fullscreen without a user action. In Firefox this creates an apparently uncatchable TypeError. I attempted locally to capture it from the rejected promise or in a larger `try-catch` block but neither worked. This is unlike [the TypeError that can be thrown if the user is prompted and rejects fullscreen](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Exceptions).

This fix adds a note to the console logs before the attempt is made. It also adds a few lines to the README to explain different ways of launching in a kiosk mode for managed deployments.

